### PR TITLE
Fix SPDX copyright headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA
-# CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.16)

--- a/cuBQL/builder/cuda/profiling_helper.h
+++ b/cuBQL/builder/cuda/profiling_helper.h
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA
-// CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/cuBQL/builder/cuda/refit.h
+++ b/cuBQL/builder/cuda/refit.h
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA
-// CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/cuBQL/builder/cuda/refit_aggregate.h
+++ b/cuBQL/builder/cuda/refit_aggregate.h
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA
-// CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/cuBQL/builder/cuda/sm_builder.h
+++ b/cuBQL/builder/cuda/sm_builder.h
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA
-// CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/cuBQL/builder/omp/AtomicBox.h
+++ b/cuBQL/builder/omp/AtomicBox.h
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA
-// CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/cuBQL/builder/omp/common.h
+++ b/cuBQL/builder/omp/common.h
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA
-// CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/cuBQL/builder/omp/spatialMedian.h
+++ b/cuBQL/builder/omp/spatialMedian.h
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA
-// CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/samples/s07_aggregateNBody/aggregateNBody.cu
+++ b/samples/s07_aggregateNBody/aggregateNBody.cu
@@ -1,5 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA
-// CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 /*! \file aggregateNBodya.cu Provides a mini-sample for how to use the


### PR DESCRIPTION
## Context

This issue was found during an Open Source Review Board (OSRB) audit of [NVIDIA Warp](https://github.com/NVIDIA/warp). Warp vendors cuBQL under `warp/native/cuBQL`, so fixing the copyright headers upstream avoids carrying a downstream-only correction.

Seven vendored builder files split `NVIDIA CORPORATION & AFFILIATES` across two comment lines. As a result, only `Copyright (c) 2025 NVIDIA` was attached to the `SPDX-FileCopyrightText` tag. A repository-wide audit found the same pattern in the top-level `CMakeLists.txt` and the aggregate N-body sample.

## Summary

Join all nine affected copyright notices so the complete legal entity appears on the `SPDX-FileCopyrightText` line. This changes comments only and has no runtime impact.

Closes #39.

## Validation

- Configured and built the CPU targets with `-DCUBQL_DISABLE_CUDA=ON`.
- Verified all NVIDIA SPDX tags are complete and no orphaned continuation lines remain.
- Ran `git diff --check`.